### PR TITLE
fix: update link with `.html` file extension

### DIFF
--- a/index.md
+++ b/index.md
@@ -1,4 +1,4 @@
 ## Notes on Books
 Recently, I read "Everything I Want to Do Is Illegal" by Joel Salatin.
 
-<a href="testlink.md">testlinkdeneme</a>
+<a href="testlink.html">testlinkdeneme</a>


### PR DESCRIPTION
Fix the link so users are taken to the rendered HTML page
rather than the raw Markdown page.